### PR TITLE
ds-graph-attr

### DIFF
--- a/docs/graph.md
+++ b/docs/graph.md
@@ -27,10 +27,9 @@ In an adjacency list, every vertex keeps track of it's neighboring/adjacent vert
 
 ```python
 class Graph:
-    def __init__(self, adj_list={}, directed=False, multigraph=False):
-        self._adj = defaultdict(list)
+    def __init__(self, adj_list={}, directed=False):
+        self._adj = defaultdict(dict)
         self._directed = directed
-        self._multigraph = multigraph
         self.add_edges(adj_list=adj_list)
 
     def __getitem__(self, vertex):
@@ -42,27 +41,25 @@ class Graph:
     def __delitem__(self, vertex):
         del self._adj[vertex]
         for u, adj in self._adj.items():
-            self._adj[u] = [val for val in adj if val != vertex]
+            if vertex in self._adj[u]:
+                del self._adj[u][vertex]
 
     def __len__(self):
         return len(self._adj)
 
-    def add_edges(self, adj_list={}, edge_list=[]):
+    def add_edges(self, adj_list={}):
         for u, adj in adj_list.items():
-            for v in adj:
-                self.add_edge(u, v)
+            for v, attr in adj.items():
+                self.add_edge(u, v, attr)
 
-        for edge in edge_list:
-            self.add_edge(edge[0], edge[1])
-
-    def add_edge(self, u_of_edge, v_of_edge):
-        if u_of_edge in self._adj and v_of_edge in self._adj[u_of_edge] and not self._multigraph:
+    def add_edge(self, u_of_edge, v_of_edge, attributes={}):
+        if u_of_edge in self._adj and v_of_edge in self._adj[u_of_edge]:
             raise Exception
 
-        self._adj[u_of_edge].append(v_of_edge)
+        self._adj[u_of_edge][v_of_edge] = attributes
         self._adj[v_of_edge]
         if not self._directed and u_of_edge != v_of_edge:
-            self._adj[v_of_edge].append(u_of_edge)
+            self._adj[v_of_edge][u_of_edge] = attributes
 ```
 
 ## <a name="adj_matrix"></a> Adjacency Matrix

--- a/notes.txt
+++ b/notes.txt
@@ -1,10 +1,3 @@
-TODO:
-    - remove sections as they are completed
-    - figure out how to install mathjax and update equations, etc.
-
-https://github.com/yangshun/tech-interview-handbook
- https://github.com/yangshun/lago
-
 Fundamentals (https://www.tug.org/texshowcase/cheat.pdf)
     Numeral Systems (binary, decimal, hex)
         https://www.rapidtables.com/math/number/Numeral_system.html
@@ -34,13 +27,6 @@ Fundamentals (https://www.tug.org/texshowcase/cheat.pdf)
         see chapter in nn book
 
     Linear Algebra
-
-Algorithms
-    http://mimoza.marmara.edu.tr/~msakalli/cse706_12/SkienaTheAlgorithmDesignManual.pdf
-
-    Machine Learning
-
-Data Structures
    
 
 syntax: /repos/:user/:repo [GET]

--- a/pyprep/data_structures/graph/graph.py
+++ b/pyprep/data_structures/graph/graph.py
@@ -2,10 +2,9 @@ from collections import defaultdict
 
 
 class Graph:
-    def __init__(self, adj_list={}, directed=False, multigraph=False):
-        self._adj = defaultdict(list)
+    def __init__(self, adj_list={}, directed=False):
+        self._adj = defaultdict(dict)
         self._directed = directed
-        self._multigraph = multigraph
         self.add_edges(adj_list=adj_list)
 
     def __getitem__(self, vertex):
@@ -17,25 +16,22 @@ class Graph:
     def __delitem__(self, vertex):
         del self._adj[vertex]
         for u, adj in self._adj.items():
-            self._adj[u] = [val for val in adj if val != vertex]
+            if vertex in self._adj[u]:
+                del self._adj[u][vertex]
 
     def __len__(self):
         return len(self._adj)
 
-    def add_edges(self, adj_list={}, edge_list=[]):
+    def add_edges(self, adj_list={}):
         for u, adj in adj_list.items():
-            for v in adj:
-                self.add_edge(u, v)
+            for v, attr in adj.items():
+                self.add_edge(u, v, attr)
 
-        for edge in edge_list:
-            self.add_edge(edge[0], edge[1])
-
-    def add_edge(self, u_of_edge, v_of_edge):
-        if u_of_edge in self._adj and v_of_edge in self._adj[u_of_edge] and not self._multigraph:
+    def add_edge(self, u_of_edge, v_of_edge, attributes={}):
+        if u_of_edge in self._adj and v_of_edge in self._adj[u_of_edge]:
             raise Exception
 
-        self._adj[u_of_edge].append(v_of_edge)
+        self._adj[u_of_edge][v_of_edge] = attributes
         self._adj[v_of_edge]
         if not self._directed and u_of_edge != v_of_edge:
-            self._adj[v_of_edge].append(u_of_edge)
-            
+            self._adj[v_of_edge][u_of_edge] = attributes

--- a/pyprep/tests/test_algorithms/test_graph/test_search.py
+++ b/pyprep/tests/test_algorithms/test_graph/test_search.py
@@ -15,47 +15,26 @@ class TestStack(unittest.TestCase):
         self.func = partial(f, self.path)
         
         graph_adj_list = {
-            0: [1, 2, 3],
-            1: [4, 5],
-            2: [5],
-            3: [6],
-            4: [6],
-            5: [7],
-            6: [6]
+            0: {1:{}, 2:{}, 3:{}},
+            1: {4:{}, 5:{}},
+            2: {5:{}},
+            3: {6:{}},
+            4: {6:{}},
+            5: {7:{}},
+            6: {6:{}}
         }
         digraph_adj_list = {
-            0: [1, 2, 3],
-            1: [0, 4, 5],
-            2: [5],
-            3: [0, 6],
-            4: [1, 6],
-            5: [7],
-            6: [],
-            7: [7]
+            0: {1:{}, 2:{}, 3:{}},
+            1: {0:{}, 4:{}, 5:{}},
+            2: {5:{}},
+            3: {0:{}, 6:{}},
+            4: {1:{}, 6:{}},
+            5: {7:{}},
+            6: {},
+            7: {7:{}}
         }
-        multigraph_adj_list = {
-            0: [1, 2, 3],
-            1: [0, 4, 5, 7],
-            2: [5, 5],
-            3: [6],
-            4: [6],
-            5: [1, 2, 7],
-            6: [6, 6]
-        }
-        multidigraph_adj_list = {
-            0: [1, 1, 2, 3],
-            1: [0, 4, 5],
-            2: [5],
-            3: [6],
-            4: [1, 6, 6],
-            5: [7],
-            6: [],
-            7: [7, 7]
-        }
-        self.graph = Graph(graph_adj_list, directed=False, multigraph=False)
-        self.digraph = Graph(digraph_adj_list, directed=True, multigraph=False)
-        self.multigraph = Graph(multigraph_adj_list, directed=False, multigraph=True)
-        self.multidigraph = Graph(multidigraph_adj_list, directed=True, multigraph=True)
+        self.graph = Graph(graph_adj_list, directed=False)
+        self.digraph = Graph(digraph_adj_list, directed=True)
 
     def test_dfs_graph(self):
         dfs(self.graph, 0, self.func)
@@ -65,25 +44,11 @@ class TestStack(unittest.TestCase):
         dfs(self.digraph, 0, self.func)
         self.assertEqual(self.path, [0, 1, 4, 6, 5, 7, 2, 3])
 
-    def test_dfs_multigraph(self):
-        dfs(self.multigraph, 0, self.func)
-        self.assertEqual(self.path, [0, 1, 4, 6, 3, 5, 2, 7])
-
-    def test_dfs_multidigraph(self):
-        dfs(self.multidigraph, 0, self.func)
-        self.assertEqual(self.path, [0, 1, 4, 6, 5, 7, 2, 3])
-
     def test_dfs_missing_graph(self):
         self.assertRaises(KeyError, dfs, self.graph, 8, self.func)
 
     def test_dfs_missing_digraph(self):
         self.assertRaises(KeyError, dfs, self.digraph, 8, self.func)
-
-    def test_dfs_missing_multigraph(self):
-        self.assertRaises(KeyError, dfs, self.multigraph, 8, self.func)
-    
-    def test_dfs_missing_multidigraph(self):
-        self.assertRaises(KeyError, dfs, self.multidigraph, 8, self.func)
 
     def test_bfs_graph(self):
         bfs(self.graph, 0, self.func)
@@ -93,22 +58,8 @@ class TestStack(unittest.TestCase):
         bfs(self.digraph, 0, self.func)
         self.assertEqual(self.path, [0, 1, 2, 3, 4, 5, 6, 7])
 
-    def test_bfs_multigraph(self):
-        bfs(self.multigraph, 0, self.func)
-        self.assertEqual(self.path, [0, 1, 2, 3, 4, 5, 7, 6])
-
-    def test_bfs_multidigraph(self):
-        bfs(self.multidigraph, 0, self.func)
-        self.assertEqual(self.path, [0, 1, 2, 3, 4, 5, 6, 7])
-
     def test_bfs_missing_graph(self):
         self.assertRaises(KeyError, bfs, self.graph, 8, self.func)
 
     def test_bfs_missing_digraph(self):
         self.assertRaises(KeyError, bfs, self.digraph, 8, self.func)
-
-    def test_bfs_missing_multigraph(self):
-        self.assertRaises(KeyError, bfs, self.multigraph, 8, self.func)
-    
-    def test_bfs_missing_multidigraph(self):
-        self.assertRaises(KeyError, bfs, self.multidigraph, 8, self.func)

--- a/pyprep/tests/test_data_structures/test_graph/test_graph.py
+++ b/pyprep/tests/test_data_structures/test_graph/test_graph.py
@@ -5,110 +5,85 @@ from data_structures.graph.graph import Graph
 
 class TestStack(unittest.TestCase):
     def setUp(self):
+        self.attr_key = 'w'
         graph_adj_list = {
-            0: [1, 2, 3],
-            1: [4, 5],
-            2: [5],
-            3: [6],
-            4: [6],
-            5: [7],
-            6: [6]
+            0: {1:{}, 2:{}, 3:{}},
+            1: {4:{}, 5:{}},
+            2: {5:{}},
+            3: {6:{}},
+            4: {6:{}},
+            5: {7:{}},
+            6: {6:{}}
         }
         digraph_adj_list = {
-            0: [1, 2, 3],
-            1: [0, 4, 5],
-            2: [5],
-            3: [0, 6],
-            4: [1, 6],
-            5: [7],
-            6: [],
-            7: [7]
+            0: {1:{}, 2:{}, 3:{}},
+            1: {0:{}, 4:{}, 5:{}},
+            2: {5:{}},
+            3: {0:{}, 6:{}},
+            4: {1:{}, 6:{}},
+            5: {7:{}},
+            6: {},
+            7: {7:{}}
         }
-        multigraph_adj_list = {
-            0: [1, 2, 3],
-            1: [0, 4, 5, 7],
-            2: [5, 5],
-            3: [6],
-            4: [6],
-            5: [1, 2, 7],
-            6: [6, 6]
+        graph_adj_list_attr = {
+            0: {1:{self.attr_key: 1.0}, 2:{self.attr_key: 0.5}, 3:{self.attr_key: 9.7}},
+            1: {4:{self.attr_key: 4.2}, 5:{self.attr_key: 4.3}},
+            2: {5:{self.attr_key: 8.8}},
+            3: {6:{self.attr_key: 1.1}},
+            4: {6:{self.attr_key: 4.3}},
+            5: {7:{self.attr_key: 0.1}},
+            6: {6:{self.attr_key: 9.7}}
         }
-        multidigraph_adj_list = {
-            0: [1, 1, 2, 3],
-            1: [0, 4, 5],
-            2: [5],
-            3: [6],
-            4: [1, 6, 6],
-            5: [7],
-            6: [],
-            7: [7, 7]
-        }
-        self.graph = Graph(graph_adj_list, directed=False, multigraph=False)
-        self.digraph = Graph(digraph_adj_list, directed=True, multigraph=False)
-        self.multigraph = Graph(multigraph_adj_list, directed=False, multigraph=True)
-        self.multidigraph = Graph(multidigraph_adj_list, directed=True, multigraph=True)
+        self.graph = Graph(graph_adj_list, directed=False)
+        self.digraph = Graph(digraph_adj_list, directed=True)
+        self.graph_attr = Graph(graph_adj_list_attr, directed=False)
 
     def test_construct_graph(self):
-        self.assertEqual(sorted(self.graph[0]), [1, 2, 3])
-        self.assertEqual(sorted(self.graph[1]), [0, 4, 5])
-        self.assertEqual(sorted(self.graph[2]), [0, 5])
-        self.assertEqual(sorted(self.graph[3]), [0, 6])
-        self.assertEqual(sorted(self.graph[4]), [1, 6])
-        self.assertEqual(sorted(self.graph[5]), [1, 2, 7])
-        self.assertEqual(sorted(self.graph[6]), [3, 4, 6])
-        self.assertEqual(sorted(self.graph[7]), [5])
+        self.assertEqual(self.graph[0], {1: {}, 2: {}, 3: {}})
+        self.assertEqual(self.graph[1], {0: {}, 4: {}, 5: {}})
+        self.assertEqual(self.graph[2], {0: {}, 5: {}})
+        self.assertEqual(self.graph[3], {0: {}, 6: {}})
+        self.assertEqual(self.graph[4], {1: {}, 6: {}})
+        self.assertEqual(self.graph[5], {1: {}, 2: {}, 7: {}})
+        self.assertEqual(self.graph[6], {3: {}, 4: {}, 6: {}})
+        self.assertEqual(self.graph[7], {5: {}})
 
     def test_construct_digraph(self):
-        self.assertEqual(sorted(self.digraph[0]), [1, 2, 3])
-        self.assertEqual(sorted(self.digraph[1]), [0, 4, 5])
-        self.assertEqual(sorted(self.digraph[2]), [5])
-        self.assertEqual(sorted(self.digraph[3]), [0, 6])
-        self.assertEqual(sorted(self.digraph[4]), [1, 6])
-        self.assertEqual(sorted(self.digraph[5]), [7])
-        self.assertEqual(sorted(self.digraph[6]), [])
-        self.assertEqual(sorted(self.digraph[7]), [7])
+        self.assertEqual(self.digraph[0], {1:{}, 2:{}, 3:{}})
+        self.assertEqual(self.digraph[1], {0:{}, 4:{}, 5:{}})
+        self.assertEqual(self.digraph[2], {5:{}})
+        self.assertEqual(self.digraph[3], {0:{}, 6:{}})
+        self.assertEqual(self.digraph[4], {1:{}, 6:{}})
+        self.assertEqual(self.digraph[5], {7:{}})
+        self.assertEqual(self.digraph[6], {})
+        self.assertEqual(self.digraph[7], {7:{}})
 
-    def test_construct_multigraph(self):
-        self.assertEqual(sorted(self.multigraph[0]), [1, 1, 2, 3])
-        self.assertEqual(sorted(self.multigraph[1]), [0, 0, 4, 5, 5, 7])
-        self.assertEqual(sorted(self.multigraph[2]), [0, 5, 5, 5])
-        self.assertEqual(sorted(self.multigraph[3]), [0, 6])
-        self.assertEqual(sorted(self.multigraph[4]), [1, 6])
-        self.assertEqual(sorted(self.multigraph[5]), [1, 1, 2, 2, 2, 7])
-        self.assertEqual(sorted(self.multigraph[6]), [3, 4, 6, 6])
-        self.assertEqual(sorted(self.multigraph[7]), [1, 5])
-
-    def test_construct_multidigraph(self):
-        self.assertEqual(sorted(self.multidigraph[0]), [1, 1, 2, 3])
-        self.assertEqual(sorted(self.multidigraph[1]), [0, 4, 5])
-        self.assertEqual(sorted(self.multidigraph[2]), [5])
-        self.assertEqual(sorted(self.multidigraph[3]), [6])
-        self.assertEqual(sorted(self.multidigraph[4]), [1, 6, 6])
-        self.assertEqual(sorted(self.multidigraph[5]), [7])
-        self.assertEqual(sorted(self.multidigraph[6]), [])
-        self.assertEqual(sorted(self.multidigraph[7]), [7, 7])
+    def test_construct_graph_attributes(self):
+        self.assertEqual(self.graph_attr[0], {1:{self.attr_key: 1.0}, 2: {self.attr_key: 0.5}, 3:{self.attr_key: 9.7}})
+        self.assertEqual(self.graph_attr[1], {0:{self.attr_key: 1.0}, 4:{self.attr_key: 4.2}, 5:{self.attr_key: 4.3}})
+        self.assertEqual(self.graph_attr[2], {0:{self.attr_key: 0.5}, 5:{self.attr_key: 8.8}})
+        self.assertEqual(self.graph_attr[3], {0:{self.attr_key: 9.7}, 6:{self.attr_key: 1.1}})
+        self.assertEqual(self.graph_attr[4], {1:{self.attr_key: 4.2}, 6:{self.attr_key: 4.3}})
+        self.assertEqual(self.graph_attr[5], {1:{self.attr_key: 4.3}, 2:{self.attr_key: 8.8}, 7:{self.attr_key: 0.1}})
+        self.assertEqual(self.graph_attr[6], {3:{self.attr_key: 1.1}, 4:{self.attr_key: 4.3}, 6:{self.attr_key: 9.7}})
+        self.assertEqual(self.graph_attr[7], {5:{self.attr_key: 0.1}})
 
     def test_add_edge_graph(self):
         self.graph.add_edge(2, 3)
-        self.assertEqual(sorted(self.graph[2]), [0, 3, 5])
-        self.assertEqual(sorted(self.graph[3]), [0, 2, 6])
+        self.assertEqual(self.graph[2], {0:{}, 3:{}, 5:{}})
+        self.assertEqual(self.graph[3], {0:{}, 2:{}, 6:{}})
     
     def test_add_edge_digraph(self):
         self.digraph.add_edge(2, 3)
-        self.assertEqual(sorted(self.digraph[2]), [3, 5])
-        self.assertEqual(sorted(self.digraph[3]), [0, 6])
-        
-    def test_add_edge_multigraph(self):
-        self.multigraph.add_edge(2, 3)
-        self.multigraph.add_edge(2, 3)
-        self.assertEqual(sorted(self.multigraph[2]), [0, 3, 3, 5, 5, 5])
-        self.assertEqual(sorted(self.multigraph[3]), [0, 2, 2, 6])
+        self.assertEqual(self.digraph[2], {3:{}, 5:{}})
+        self.assertEqual(self.digraph[3], {0:{}, 6:{}})
 
-    def test_add_edge_multidigraph(self):
-        self.multidigraph.add_edge(2, 3)
-        self.multidigraph.add_edge(2, 3)
-        self.assertEqual(sorted(self.multidigraph[2]), [3, 3, 5])
-        self.assertEqual(sorted(self.multidigraph[3]), [6])
+    def test_add_edge_graph_attr(self):
+        test_attr_key = 'clr'
+        test_attr_val = 'R'
+        self.graph_attr.add_edge(2, 3, {self.attr_key: 7.7, test_attr_key: test_attr_val})
+        self.assertEqual(self.graph_attr[2], {0:{self.attr_key: 0.5}, 3: {self.attr_key: 7.7, test_attr_key: test_attr_val}, 5:{self.attr_key: 8.8}})
+        self.assertEqual(self.graph_attr[3], {0:{self.attr_key: 9.7}, 2: {self.attr_key: 7.7, test_attr_key: test_attr_val}, 6:{self.attr_key: 1.1}})
 
     def test_add_edge_existing_graph(self):
         self.assertRaises(Exception, self.graph.add_edge, 0, 1)
@@ -117,123 +92,63 @@ class TestStack(unittest.TestCase):
     def test_add_edge_existing_digraph(self):
         self.assertRaises(Exception, self.digraph.add_edge, 0, 1)
 
-    def test_add_edge_existing_multigraph(self):
-        self.multigraph.add_edge(0, 1)
-        self.assertEqual(sorted(self.multigraph[0]), [1, 1, 1, 2, 3])
-        self.assertEqual(sorted(self.multigraph[1]), [0, 0, 0, 4, 5, 5, 7])
-
-    def test_add_edge_existing_multidigraph(self):
-        self.multidigraph.add_edge(0, 1)
-        self.assertEqual(sorted(self.multidigraph[0]), [1, 1, 1, 2, 3])
-        self.assertEqual(sorted(self.multidigraph[1]), [0, 4, 5])
-
     def test_add_edge_loop_graph(self):
         self.graph.add_edge(0, 0)
-        self.assertEqual(sorted(self.graph[0]), [0, 1, 2, 3])
+        self.assertEqual(self.graph[0], {0:{}, 1:{}, 2:{}, 3:{}})
     
     def test_add_edge_loop_digraph(self):
         self.digraph.add_edge(0, 0)
-        self.assertEqual(sorted(self.digraph[0]), [0, 1, 2, 3])
-    
-    def test_add_edge_loop_multigraph(self):
-        self.multigraph.add_edge(0, 0)
-        self.multigraph.add_edge(6, 6)
-        self.assertEqual(sorted(self.multigraph[0]), [0, 1, 1, 2, 3])
-        self.assertEqual(sorted(self.multigraph[6]), [3, 4, 6, 6, 6])
-
-    def test_add_edge_loop_multidigraph(self):
-        self.multidigraph.add_edge(6, 6)
-        self.multidigraph.add_edge(7, 7)
-        self.assertEqual(sorted(self.multidigraph[6]), [6])
-        self.assertEqual(sorted(self.multidigraph[7]), [7, 7, 7])
+        self.assertEqual(self.digraph[0], {0:{}, 1:{}, 2:{}, 3:{}})
 
     def test_add_edge_new_u_vertex_graph(self):
         self.graph.add_edge(8, 0)
-        self.assertEqual(sorted(self.graph[0]), [1, 2, 3, 8])
-        self.assertEqual(sorted(self.graph[8]), [0])
+        self.assertEqual(self.graph[0], {1:{}, 2:{}, 3:{}, 8:{}})
+        self.assertEqual(self.graph[8], {0:{}})
 
     def test_add_edge_new_u_vertex_digraph(self):
         self.digraph.add_edge(8, 0)
-        self.assertEqual(sorted(self.digraph[0]), [1, 2, 3])
-        self.assertEqual(sorted(self.digraph[8]), [0])
-
-    def test_add_edge_new_u_vertex_multigraph(self):
-        self.multigraph.add_edge(8, 0)
-        self.assertEqual(sorted(self.multigraph[0]), [1, 1, 2, 3, 8])
-        self.assertEqual(sorted(self.multigraph[8]), [0])
-
-    def test_add_edge_new_u_vertex_multidigraph(self):
-        self.multidigraph.add_edge(8, 0)
-        self.assertEqual(sorted(self.multidigraph[0]), [1, 1, 2, 3])
-        self.assertEqual(sorted(self.multidigraph[8]), [0])
+        self.assertEqual(self.digraph[0], {1:{}, 2:{}, 3:{}})
+        self.assertEqual(self.digraph[8], {0:{}})
 
     def test_add_edge_new_v_vertex_graph(self):
         self.graph.add_edge(0, 8)
-        self.assertEqual(sorted(self.graph[0]), [1, 2, 3, 8])
-        self.assertEqual(sorted(self.graph[8]), [0])
+        self.assertEqual(self.graph[0], {1:{}, 2:{}, 3:{}, 8:{}})
+        self.assertEqual(self.graph[8], {0:{}})
 
     def test_add_edge_new_v_vertex_digraph(self):
         self.digraph.add_edge(0, 8)
-        self.assertEqual(sorted(self.digraph[0]), [1, 2, 3, 8])
-        self.assertEqual(sorted(self.digraph[8]), [])
-    
-    def test_add_edge_new_v_vertex_multigraph(self):
-        self.multigraph.add_edge(0, 8)
-        self.assertEqual(sorted(self.multigraph[0]), [1, 1, 2, 3, 8])
-        self.assertEqual(sorted(self.multigraph[8]), [0])
-    
-    def test_add_edge_new_v_vertex_multidigraph(self):
-        self.multidigraph.add_edge(0, 8)
-        self.assertEqual(sorted(self.multidigraph[0]), [1, 1, 2, 3, 8])
-        self.assertEqual(sorted(self.multidigraph[8]), [])
+        self.assertEqual(self.digraph[0], {1:{}, 2:{}, 3:{}, 8:{}})
+        self.assertEqual(self.digraph[8], {})
 
     def test_add_edges_graph(self):
-        self.graph.add_edges(adj_list={0:[4]}, edge_list=[(2, 3)])
-        self.assertEqual(sorted(self.graph[0]), [1, 2, 3, 4])
-        self.assertEqual(sorted(self.graph[2]), [0, 3, 5])
-        self.assertEqual(sorted(self.graph[3]), [0, 2, 6])
-        self.assertEqual(sorted(self.graph[4]), [0, 1, 6])
+        self.graph.add_edges(adj_list={
+            0: {4: {}},
+            2: {3: {}}})
+        self.assertEqual(self.graph[0], {1:{}, 2:{}, 3:{}, 4:{}})
+        self.assertEqual(self.graph[2], {0:{}, 3:{}, 5:{}})
+        self.assertEqual(self.graph[3], {0:{}, 2:{}, 6:{}})
+        self.assertEqual(self.graph[4], {0:{}, 1:{}, 6:{}})
 
-    def test_size_of(self):
+    def test_len(self):
         self.assertEqual(len(self.graph), 8)
         self.assertEqual(len(self.digraph), 8)
-        self.assertEqual(len(self.multigraph), 8)
-        self.assertEqual(len(self.multidigraph), 8)
 
     def test_delete_vertex_graph(self):
         del self.graph[0]
         self.assertRaises(KeyError, self.graph.__getitem__, 0)
-        self.assertEqual(sorted(self.graph[1]), [4, 5])
-        self.assertEqual(sorted(self.graph[2]), [5])
-        self.assertEqual(sorted(self.graph[3]), [6])
+        self.assertEqual(self.graph[1], {4:{}, 5:{}})
+        self.assertEqual(self.graph[2], {5:{}})
+        self.assertEqual(self.graph[3], {6:{}})
 
     def test_delete_vertex_digraph(self):
         del self.digraph[0]
         self.assertRaises(KeyError, self.digraph.__getitem__, 0)
-        self.assertEqual(sorted(self.digraph[1]), [4, 5])
-        self.assertEqual(sorted(self.digraph[3]), [6])
-
-    def test_delete_vertex_multigraph(self):
-        del self.multigraph[0]
-        self.assertRaises(KeyError, self.multigraph.__getitem__, 0)
-        self.assertEqual(sorted(self.multigraph[1]), [4, 5, 5, 7])
-        self.assertEqual(sorted(self.multigraph[2]), [5, 5, 5])
-        self.assertEqual(sorted(self.multigraph[3]), [6])
-
-    def test_delete_vertex_multidigraph(self):
-        del self.multidigraph[0]
-        self.assertRaises(KeyError, self.multidigraph.__getitem__, 0)
-        self.assertEqual(sorted(self.multidigraph[1]), [4, 5])
+        self.assertEqual(self.digraph[1], {4:{}, 5:{}})
+        self.assertEqual(self.digraph[3], {6:{}})
 
     def test_delete_missing_vertex_graph(self):
         self.assertRaises(KeyError, self.graph.__delitem__, 8)
 
     def test_delete_missing_vertex_digraph(self):
         self.assertRaises(KeyError, self.digraph.__delitem__, 8)
-
-    def test_delete_missing_vertex_multigraph(self):
-        self.assertRaises(KeyError, self.multigraph.__delitem__, 8)
-
-    def test_delete_missing_vertex_multidigraph(self):
-        self.assertRaises(KeyError, self.multidigraph.__delitem__, 8)
         


### PR DESCRIPTION
## Issue
19

## Proposed changes
Add ability to have attributes on graph edges (weight, etc). Implemented as nested dictionaries, forcing the removal of the multi-graph option (multi-graphs can still be implemented by using attributes: i.e. two different weight attributes, etc.). Attributes also serve as the precursor to the planned implementation of rule-enforced trees.
